### PR TITLE
fix: add command with as folding marker

### DIFF
--- a/grammars/hugo.cson
+++ b/grammars/hugo.cson
@@ -1,7 +1,7 @@
 'scopeName': 'text.html.hugo'
 'name': 'Hugo'
 'fileTypes': ['md', 'mmark', 'html']
-'foldingStartMarker':'({{(.*)range(.*)}})|({{(.*)if(.*))'
+'foldingStartMarker':'({{(.*)range(.*)}})|({{(.*)if(.*))|({{(.*)with(.*))'
 'foldingStopMarker':'({{(.*)end(.*)}})'
 
 'patterns': [


### PR DESCRIPTION
Adding `with` as a folding marker to `range` and `if`. 