### PR TITLE
feat: add gotemplate as pattern base

### DIFF
--- a/grammars/hugo.cson
+++ b/grammars/hugo.cson
@@ -1,7 +1,7 @@
 'scopeName': 'text.html.hugo'
 'name': 'Hugo'
 'fileTypes': ['md', 'mmark', 'html']
-'foldingStartMarker':'({{(.*)range(.*)}})|({{(.*)if(.*))'
+'foldingStartMarker':'({{(.*)range(.*)}})|({{(.*)if(.*))|({{(.*)with(.*))'
 'foldingStopMarker':'({{(.*)end(.*)}})'
 
 'patterns': [

--- a/grammars/hugo.cson
+++ b/grammars/hugo.cson
@@ -9,6 +9,9 @@
     'include': 'text.html.basic'
   }
   {
+    'include': 'source.gotemplate'
+  }
+  {
     'include': 'source.gfm'
   }
   {


### PR DESCRIPTION
This adds gotemplate as a pattern base (up to now only HTML). I am not sure how far this is overridden by settings in our local files. I would expect that everything we set in the local configuration will override and not merge with the base configurations.